### PR TITLE
fix mafia warning about Ed class name

### DIFF
--- a/src/relay/charpane.ash
+++ b/src/relay/charpane.ash
@@ -3111,7 +3111,7 @@ void bakeStats() {
 			case $class[Avatar of Sneaky Pete]:
 				result.addAud();
 				break;
-			case $class[Ed]:
+			case $class[Ed the Undying]:
 				result.addKa();
 				break;
 			case $class[Gelatinous Noob]:
@@ -3630,7 +3630,7 @@ void bakeCharacter() {
 			return "da.php?place=gate2";
 		case $class[Avatar of Sneaky Pete]:
 			return "da.php?place=gate3";
-		case $class[Ed]:
+		case $class[Ed the Undying]:
 			return "place.php?whichplace=edbase&action=edbase_book";
 		case $class[Cow Puncher]:
 		case $class[Beanslinger]:


### PR DESCRIPTION
fixes these mafia warnings:
```
Changing "Ed" to "Ed the Undying" would get rid of this message. (charpane.ash, line 3045)
Changing "Ed" to "Ed the Undying" would get rid of this message. (charpane.ash, line 3564)
```