### PR TITLE
additional brick layout options

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -120,17 +120,19 @@ Simply place your bricks in the area you want, in the order you want them.
 The roof, walls and floor of your house can use some special syntax to lay bricks out in rows and columns.
 - | separator places bricks or groups of bricks horizontally adjacent each other in a row
 - , separator starts a new row of bricks after the previous row
-- () parens vertically group bricks
-- {} curly braces horizontally group bricks
+- ( ) parens vertically group bricks
+- { } curly braces horizontally group bricks
+
 Overriding the width of a brick or group of bricks can be accomplished by adding the following suffix immediately after it:
 - :X% sets its width to X%.
 - :Xpx sets its width equal to X pixels.
 - :X\* sets its width to be X times wider than the default width of bricks in that row.
+
 If no width override is supplied, ChIT tries to make all bricks in the same row the same width, content allowing.
 
 examples:
-- character|gear:112px,stats:3\*|{familiar,trail}:2\*
-- effects:2\*|{trail,gear,familiar,boombox}
+- character|gear:112px,stats:3\*|(familiar,trail):2\*
+- effects:2\*|(trail,gear,familiar,boombox)
 
 Each brick may have an icon at the top left in it's title bar.
 When the icon is clicked, the contents of the walls will (temporarily) "stretch" over the roof space.

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,16 +106,31 @@ Inside each area you can place any of the following "bricks":
 So how do you design and build your own house? Easy.
 Simply place your bricks in the area you want, in the order you want them.
 
-- chit.roof.layout: Comma-separated list of bricks to place in your roof
+- chit.roof.layout: List of bricks to place in your roof
   - Default: character,stats,gear
-- chit.walls.layout: Comma-separated list of bricks to place in your walls
+- chit.walls.layout: List of bricks to place in your walls
   - Default: helpers,thrall,robo,vykea,effects,horsery,boombox
-- chit.floor.layout: Comma-separated list of bricks to place in your floor
+- chit.floor.layout: List of bricks to place in your floor
   - Default: update,familiar
 - chit.toolbar.layout: Comma-separated list of bricks to place in the toolbar
   - Special values:
     - disable - a brick you can add here which is actually a small button to disable ChIT.
   - Default: trail,quests,modifiers,elements,organs
+
+The roof, walls and floor of your house can use some special syntax to lay bricks out in rows and columns.
+- | separator places bricks or groups of bricks horizontally adjacent each other in a row
+- , separator starts a new row of bricks after the previous row
+- () parens vertically group bricks
+- {} curly braces horizontally group bricks
+Overriding the width of a brick or group of bricks can be accomplished by adding the following suffix immediately after it:
+- :X% sets its width to X%.
+- :Xpx sets its width equal to X pixels.
+- :X\* sets its width to be X times wider than the default width of bricks in that row.
+If no width override is supplied, ChIT tries to make all bricks in the same row the same width, content allowing.
+
+examples:
+- character|gear:112px,stats:3\*|{familiar,trail}:2\*
+- effects:2\*|{trail,gear,familiar,boombox}
 
 Each brick may have an icon at the top left in it's title bar.
 When the icon is clicked, the contents of the walls will (temporarily) "stretch" over the roof space.

--- a/src/relay/charpane.ash
+++ b/src/relay/charpane.ash
@@ -4443,7 +4443,7 @@ string[int] tokenize(string str, boolean[string] glues) {
 			//if no glue was found at the start of str, remove the first character from str
 			//and add it to ctoken. It will be added to the list of tokens when another glue
 			//or end-of-string is found.
-			append(ctoken, substring(str,0,1));
+			ctoken.append(substring(str,0,1));
 			str = substring(str,1);
 			loop = true;
 		}
@@ -4532,9 +4532,13 @@ buffer addGroup(string[int] rowHTMLs, string className) {
 buffer addRow(string[int] bricks, string[int] styleInfos) {
 //adds bricks or groups of bricks into horizontal rows
 	buffer buff;
+	string s2;
 	int totalStars = starCount(styleInfos) + count(bricks) - count(styleInfos);
 	foreach i,s in bricks {
-		append(buff, '<div class="brick_holder" '+stylize(styleInfos[i],totalStars)+'>'+s+'</div>');
+		int ind = index_of(s,">");
+		string s2 = substring(s,0,ind) + " " + stylize(styleInfos[i],totalStars) + substring(s,ind);
+		append(buff, s2);
+		//append(buff, '<div class="brick_holder" '+stylize(styleInfos[i],totalStars)+'>'+s+'</div>');
 	}
 	return buff;
 }
@@ -4612,15 +4616,15 @@ buffer addBricks(string layout) {
 					case "footer":
 						break;	//Special Bricks that are inserted manually in the correct places
 					default:
-						if(chitBricks contains s && chitBricks[s] != "") {
-							bricks[pLevel,i[pLevel]] = chitBricks[s];
+						if(chitBricks[s] != "") {
+							bricks[pLevel,i[pLevel]] = '<div class="brick_holder">' + chitBricks[s] + '</div>';
 						}
 						break;
 				}
 			}
 		}
 		if(pLevel != 0)
-			append(result, "<span>Malformed chit layout (mismatched parentheses): " + layout + "<span>");
+			result.append('<div class="error_message"><span>Malformed chit layout (mismatched parentheses): </span><span class="code"' + layout + '</span></div>');
 		while(pLevel > 0){
 			rowHTML[pLevel,j[pLevel]] = addRow(bricks[pLevel], styleInfo[pLevel]);
 			bricks[pLevel-1,i[pLevel-1]] = addGroup(rowHTML[pLevel],"brick_row");
@@ -4631,7 +4635,7 @@ buffer addBricks(string layout) {
 			pLevel--;
 		}
 		rowHTML[pLevel,j[pLevel]] = addRow(bricks[pLevel], styleInfo[pLevel]);
-		append(result, addGroup(rowHTML[pLevel],"brick_row"));
+		result.append(addGroup(rowHTML[pLevel],"brick_row"));
 		return result;
 	}
 	

--- a/src/relay/charpane.ash
+++ b/src/relay/charpane.ash
@@ -4366,10 +4366,8 @@ void bakeBricks() {
 		bakeValhalla();
 	} else {
 		foreach layout in $strings[roof, walls, floor, toolbar] {
-			string [int] bricks = split_string(vars["chit." + layout + ".layout"],",");
-			string brick;
-			for i from 0 to (bricks.count()-1) {
-				brick = bricks[i];
+			foreach i,s in split_string(vars["chit."+layout+".layout"],"[,\\|(){}]") {
+				string brick = split_string(s,":")[0]; //content after ":" is style info
 				if (!(chitBricks contains brick)) {
 					switch (brick) {
 						case "character":	bakeCharacter();	break;
@@ -4412,26 +4410,234 @@ void bakeBricks() {
 
 }
 
-buffer addBricks(string layout) {
 
-	buffer result;
-	if (layout != "") {
-		string [int] bricks = split_string(layout,",");
-		string brick;
-		for i from 0 to (bricks.count()-1) {
-			brick = bricks[i];
-			switch (brick) {
-				case "toolbar":
-				case "header":
-				case "footer":
-					break;	//Special Bricks that are inserted manually in the correct places
+string[int] tokenize(string str, boolean[string] glues) {
+// splits up a string into tokens, which include the passed in glues, and the stuff between glues.
+// example: str="(1,alpha,33.3)", glues=$strings[\,,(,)]
+// -> returns [0:"(", 1:"1", 2:",", 3:"alpha", 4:",", 5:"33.3", 6:")"]
+	string[int] tokens;
+	buffer ctoken;
+	int j = 0;
+	boolean loop = true;
+	while(length(str) > 0){ // works through str one character at a time at a time
+		while(loop){
+			loop = false;
+			foreach s,b in glues {
+				if(length(s) <= length(str) && s == substring(str, 0, length(s))) {
+				//if a glue is found at the current portion of the string
+					loop = true;
+					if(length(ctoken) != 0){
+					//add non-zero length non-glue to list of tokens.
+						tokens[j] = ctoken;
+						set_length(ctoken,0);
+						j++;
+					}
+					//add found glue to list of tokens, and delete it from the front of str
+					tokens[j] = s;
+					str = substring(str,length(s));
+					j++;
+				}
+			}
+		}
+		if(length(str) > 0) {
+			//if no glue was found at the start of str, remove the first character from str
+			//and add it to ctoken. It will be added to the list of tokens when another glue
+			//or end-of-string is found.
+			append(ctoken, substring(str,0,1));
+			str = substring(str,1);
+			loop = true;
+		}
+	}
+	if(length(ctoken) > 0)
+		//add non-zero length last non-glue token to list of tokens.
+		tokens[j] = ctoken;
+	return tokens;
+}
+
+
+
+float starCount(string[int] styleInfos) {
+	//counts the number of stars "*" in the current row of bricks
+	//used to decide what css width should be set to a brick or group of bricks.
+	float starCountHelper(string styleInfo) {
+		buffer bnum;
+		string[int] tokens = tokenize(styleInfo, $strings[*,%,px]);
+		float num = 1;
+		foreach i,s in tokens {
+			switch(s){
+			// a number before a "*" will return that number. Everything else will return 1.
+				case "%":
+				case "px":
+					num = 1;
+					break;
+				case "*":
+					return num;
 				default:
-					result.append(chitBricks[brick]);
+					num = to_float(s);
+			}
+		}
+		return 1;
+	}
+	
+	float total = 0;
+	foreach i,s in styleInfos {
+		total += starCountHelper(s);
+	}
+	return total;
+}
+
+string stylize(string styleInfo, int total_stars) {
+//returns an appropriate width style to a brick or group of bricks, based on user's chit layout preference
+	string[int] tokens = tokenize(styleInfo, $strings[*,%,px]);
+	string style = "";
+	float num = 0;
+	foreach i,s in tokens {
+		switch(s){
+			case "*":
+				style += "width:" + (100.0 * max(num,1)/total_stars) +"%;";
+				break;
+			case "px":
+				style += "min-width:" + num + "px;";
+				style += "max-width:" + num + "px;";
+				break;
+			case "%":
+				style += "width:" + num + "%;";
+				break;
+			default:
+				num = to_float(s);
+		}
+	}
+	if(style == "")
+		style = "width:" + (100.0 * max(num,1)/total_stars) +"%;";
+	
+	return 'style="' + style + '"';
+}
+
+buffer addGroup(string[int] rowHTMLs, string className) {
+//adds rows of bricks into a vertical group
+	buffer buff;
+	if(className != "")
+		append(buff, '<div class='+className+'>');
+		
+	foreach i,s in rowHTMLs {
+		append(buff, s);
+	}
+	
+	if(className != "")
+		append(buff, '</div>');
+
+	return buff;
+}
+
+buffer addRow(string[int] bricks, string[int] styleInfos) {
+//adds bricks or groups of bricks into horizontal rows
+	buffer buff;
+	string brick;
+	int totalStars = starCount(styleInfos) + count(bricks) - count(styleInfos);
+	//append(buff, '<div class="brick_row">');
+	foreach i,s in bricks {
+		brick = s;
+		if(chitBricks contains s) {
+			brick = chitBricks[s];
+		} else {
+			if(length(s) == 0 || substring(s,0,1) != "<")
+				brick = "";
+		}
+		if(length(brick) > 0) {
+			append(buff, '<div class="brick_holder" '+stylize(styleInfos[i],totalStars)+'>'+brick+'</div>');
+		}
+	}
+	//append(buff, '</div>');
+	return buff;
+}
+
+buffer addBricks (string[int] tokens) {
+//parses a chit.__.layout string and adding bricks in appropriate rows and columns,
+//with user-specified widths for the various bricks and groups of bricks
+//uses multi-dimensional arrays for tracking arrays at different parenthesis depth.
+	buffer result; 
+	string[int,int] bricks;
+	string[int,int] rowHTML;
+	string[int,int] styleInfo;
+	string brick;
+	boolean read_style = false;
+	int pLevel = 0;
+	int[int] i = {0:0};
+	int[int] j = {0:0};
+	foreach n,s in tokens {
+		if(read_style){
+			styleInfo[pLevel,i[pLevel]] = tokens[n];
+			read_style = false;
+		} else {
+			switch(s) {
+				case "": break;
+				case ":":
+				//next token tells us how wide this last element should be
+					read_style = true;
+					break;
+				case "|":
+				//next element will be horizontally adjacent to this one
+					i[pLevel]++;
+					break;
+				case ",":
+				//next element will start a new row below this one
+					rowHTML[pLevel,j[pLevel]] = addRow(bricks[pLevel], styleInfo[pLevel]);
+					i[pLevel]=0;
+					j[pLevel]++;
+					bricks[pLevel]={};
+					styleInfo[pLevel]={};
+					break;
+				case "{":
+				case "(":
+				//parenthesis depth increased. Pause current group parsing and start a new one.
+					pLevel++;
+					i[pLevel] = 0;
+					j[pLevel] = 0;
+					bricks[pLevel] = {};
+					styleInfo[pLevel] = {};
+					break;
+				case "}":
+				//vertical group complete. Add it to the list of bricks in the previous parenthesis depth and continue there.
+					rowHTML[pLevel,j[pLevel]] = addRow(bricks[pLevel], styleInfo[pLevel]);
+					bricks[pLevel-1,i[pLevel-1]] = addGroup(rowHTML[pLevel],"brick_column");
+					i[pLevel] = 0;
+					j[pLevel] = 0;
+					bricks[pLevel] = {};
+					styleInfo[pLevel] = {};
+					pLevel--;
+					break;
+				case ")":
+				//horizontal row complete. Add it to the list of bricks in the previous parenthesis depth and continue there.
+					rowHTML[pLevel,j[pLevel]] = addRow(bricks[pLevel], styleInfo[pLevel]);
+					bricks[pLevel-1,i[pLevel-1]] = addGroup(rowHTML[pLevel],"brick_row");
+					i[pLevel] = 0;
+					j[pLevel] = 0;
+					bricks[pLevel] = {};
+					styleInfo[pLevel] = {};
+					pLevel--;
+					break;
+				default:
+					switch (s) {
+						case "toolbar":
+						case "header":
+						case "footer":
+							break;	//Special Bricks that are inserted manually in the correct places
+						default:
+							bricks[pLevel,i[pLevel]] = s;
+					}
+					break;
 			}
 		}
 	}
+	rowHTML[pLevel,j[pLevel]] = addRow(bricks[pLevel], styleInfo[pLevel]);
+	append(result, addGroup(rowHTML[pLevel],"brick_row"));
 	return result;
+}
 
+buffer addBricks(string layout) {
+//receive chit.__.layout string, tokenize it, and send it for processing.
+	string[int] tokens = tokenize(layout, $strings[\,,|,(,),:,{,}]);
+	return addBricks(tokens);
 }
 
 buffer buildRoof() {

--- a/src/relay/charpane.ash
+++ b/src/relay/charpane.ash
@@ -4517,7 +4517,7 @@ buffer addGroup(string[int] rowHTMLs, string className) {
 //adds rows of bricks into a vertical group
 	buffer buff;
 	if(className != "")
-		append(buff, '<div class='+className+'>');
+		append(buff, '<div class="'+className+'">');
 		
 	foreach i,s in rowHTMLs {
 		append(buff, s);
@@ -4532,13 +4532,11 @@ buffer addGroup(string[int] rowHTMLs, string className) {
 buffer addRow(string[int] bricks, string[int] styleInfos) {
 //adds bricks or groups of bricks into horizontal rows
 	buffer buff;
-	string s2;
 	int totalStars = starCount(styleInfos) + count(bricks) - count(styleInfos);
 	foreach i,s in bricks {
-		int ind = index_of(s,">");
-		string s2 = substring(s,0,ind) + " " + stylize(styleInfos[i],totalStars) + substring(s,ind);
+		int ind = index_of(s,">"); //find place to add style
+		string s2 = substring(s,0,ind) + " " + stylize(styleInfos[i],totalStars) + substring(s,ind); //add style to brick
 		append(buff, s2);
-		//append(buff, '<div class="brick_holder" '+stylize(styleInfos[i],totalStars)+'>'+s+'</div>');
 	}
 	return buff;
 }
@@ -4564,6 +4562,7 @@ buffer addBricks(string layout) {
 				styleInfo[pLevel,i[pLevel]] = s;
 				read_style = false;
 			} else {
+				read_style = false;
 				switch(s) {
 					case "": break;
 					case ":":
@@ -4624,7 +4623,7 @@ buffer addBricks(string layout) {
 			}
 		}
 		if(pLevel != 0)
-			result.append('<div class="error_message"><span>Malformed chit layout (mismatched parentheses): </span><span class="code"' + layout + '</span></div>');
+			result.append('<div class="error_message"><span>Malformed chit layout: </span><span class="code">' + layout + '</span></div>');
 		while(pLevel > 0){
 			rowHTML[pLevel,j[pLevel]] = addRow(bricks[pLevel], styleInfo[pLevel]);
 			bricks[pLevel-1,i[pLevel-1]] = addGroup(rowHTML[pLevel],"brick_row");

--- a/src/relay/chit.css
+++ b/src/relay/chit.css
@@ -47,6 +47,50 @@ a.blue-link:hover {
 	color: #707070;
 }
 
+/* brick alignment flex containers */
+
+.chit_chamber > .brick_row {
+	margin: 0px;
+}
+
+.brick_row,
+.brick_column {
+    box-sizing: border-box;
+	display: flex;
+    align-items: stretch;
+    align-content: center;
+    justify-content: space-evenly;
+	flex-grow: 1;
+	margin: -2px;
+}
+.brick_row {
+    flex-direction: row;
+    flex-wrap: wrap;
+	height: fit-content;
+	width: 100%
+}
+.brick_column {
+    flex-direction: column;
+    flex-wrap: nowrap;
+	height: 100%;
+	/*width: fit-content;*/
+}
+.brick_column > :last-child {
+	margin-bottom: -4px;
+}
+
+.brick_holder {
+	/*min-height: 100%;*/
+    box-sizing: border-box;
+	flex-grow: 1;
+	padding: 2px;
+}
+
+.brick_holder > table {
+	width: 100%;
+	height: 100%;
+}
+
 #chit_house {
 }
 #chit_roof {

--- a/src/relay/chit.css
+++ b/src/relay/chit.css
@@ -49,10 +49,6 @@ a.blue-link:hover {
 
 /* brick alignment flex containers */
 
-.chit_chamber > .brick_row {
-	margin: 0px;
-}
-
 .brick_row,
 .brick_column {
     box-sizing: border-box;
@@ -61,7 +57,6 @@ a.blue-link:hover {
     align-content: center;
     justify-content: space-evenly;
 	flex-grow: 1;
-	margin: -2px;
 }
 .brick_row {
     flex-direction: row;
@@ -94,26 +89,32 @@ a.blue-link:hover {
 #chit_house {
 }
 #chit_roof {
-	overflow-x: hidden;
 	overflow-y: hidden;
-	margin: 2px 2px -2px 2px;
 }
 #chit_walls {
-	border-top: 1px solid #e0e0e0;
-	border-bottom: 1px solid #e0e0e0;
-	margin: -2px 2px 0px 2px;
-	overflow-x: hidden;
-	overflow-y: auto;
+	margin-top: -10px;
+	margin-bottom: -6px;
 	position: absolute;
-	width: 99%;
 }
 #chit_floor {
 	position: absolute;
+}
+
+.chit_chamber{
+	width: 100%;
 	overflow-x: hidden;
 	overflow-y: auto;
-	margin: -2px 2px 2px 2px;
-	width: 98%;
 }
+
+.chit_chamber > .brick_row {
+	padding: 2px;
+}
+
+#chit_walls > .brick_row {
+	padding-top: 0;
+	padding-bottom: 0;
+}
+
 #chit_toolbar {
 	border-collapse: separate;
 	border: 1px solid #d0d0d0;
@@ -1102,4 +1103,13 @@ div.chit_left-handman {
 
 .darkrow {
 	background-color: #e3e3e3;
+}
+
+.error_message {
+	border: 1px solid red;
+	background-color: #fdd;
+}
+
+.code {
+	font-family: monospace;
 }


### PR DESCRIPTION
Adds additional formatting options for layouts, allowing users to have rows and columns of bricks, and set widths for bricks or groups of bricks.
chit.__.layout can now use (){}|, for defining row/column configuration of bricks, and :_%, :_* or :_px for defining the width of bricks or groups of bricks.

examples:
set chit.roof.layout=character|gear:112px,stats:3*|{familiar,trail}:2*
() define horizontally aligned groups of bricks
{} define vertically alligned groups of bricks
| defines bricks horizontally adjacent to other bricks
, defines a new row of bricks
:x% means that the preceding brick or group of bricks will have a width equal to x%.
:x* means that the preceding brick or group of bricks will have a width weighted by x, compared to other bricks in the same row (defaults to weight of 1 if not set).
:xpx means that the preceding brick or group of bricks will have a width equal to x pixels.
Existing chit.__.layout strings work as usual without needing to change.

Page html includes additional div containers for each brick and each group of bricks, and width is set on these div containers. Minor changes to CSS margins, etc. are expected from this change.

# Description

Please include a summary of the change.

Fixes # (issue)

## Screenshots

Please include a screenshot both with and without your change active.

## Checklist:

- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
<img width="203" alt="ChIT revisions" src="https://user-images.githubusercontent.com/13992/162604709-d3d9c6e2-0a4a-4c5e-a06b-ad70ecf54389.PNG">

