### PR TITLE
Fix location in lucky helper

### DIFF
--- a/src/relay/charpane.ash
+++ b/src/relay/charpane.ash
@@ -413,7 +413,7 @@ string helperLucky() {
 			rewards[$location[The Hidden Temple]] = "stonewool.gif|Fight Baa'baa'bu'ran|5";
 		if(!have_outfit("Knob Goblin Elite Guard Uniform") && get_property("lastDispensaryOpen").to_int() != my_ascensions() && ($strings[step1, step2, finished] contains get_property("questL05Goblin"))
 		  && my_path() != "Way of the Surprising Fist" && my_path() != "Way of the Surprising Fist")
-			rewards[$location[Cobb's Knob Kitchens]] = "elitehelm.gif|Fight KGE Guard Captain|20";
+			rewards[$location[Cobb's Knob Barracks]] = "elitehelm.gif|Fight KGE Guard Captain|20";
 		if($strings[started, step1] contains get_property("questL08Trapper") && item_amount(to_item(get_property("trapperOre"))) < 3)
 			rewards[$location[Itznotyerzitz Mine]] = get_property("trapperOre").to_item().image + "|1 each: asbestos, chrome, and linoleum ore|0";
 		if(get_property("questL09Topping") == "started")


### PR DESCRIPTION
The lucky helper erroneously lists the cobbs knob kitchens as the location with the Elite Guard Captain combat adventure; the barracks is where the correct lucky adventure is located. This should fix that (and I should not lose any more lucky instances because I forgot that the kitchens is not where the lucky adventure I want is located!).

I cannot include a screenshot both with and without your change active because of where my account is in my ascension.

## Checklist:
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas. (not necessary, minor bugfix)
- [X] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
