### PR TITLE
Fix DSH beard predictions for non-standard classes

### DIFF
--- a/src/relay/chit_brickGear.ash
+++ b/src/relay/chit_brickGear.ash
@@ -1025,7 +1025,8 @@ effect [int] getBeardOrder() {
 	};
 
 	effect [int] beardOrder;
-	int classIdMod = my_class().to_int() % 6;
+	int classId = my_class().to_int();
+	int classIdMod = ((classId<=6)?classId:classId+1)% 6;
 	for(int i = 0; i < 11; ++i) {
 		int nextBeard = (classIdMod * i) % 11;
 		beardOrder[i] = baseBeardOrder[nextBeard];


### PR DESCRIPTION
# Description

Fixes Daylight Shavings Helmet predicting wrong upcoming beards for classes with ID greater than 6. For classes greater than 6, the game uses (classID+1)%6, not classID%6, and predictions were incorrect. Changes made and tested while in Grey You.

## Screenshots

Sorry, fixed this while I was in goo2, but I'm not in a run right now to screenshot.

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
