### PR TITLE
fixed bug in chit layout parsing

### DIFF
--- a/src/relay/charpane.ash
+++ b/src/relay/charpane.ash
@@ -4589,6 +4589,7 @@ buffer addBricks(string layout) {
 						j[pLevel] = 0;
 						bricks[pLevel] = {};
 						styleInfo[pLevel] = {};
+						rowHTML[pLevel] = {};
 						break;
 					case ")":
 					//vertical group complete. Add it to the list of bricks in the previous parenthesis depth and continue there.
@@ -4598,6 +4599,7 @@ buffer addBricks(string layout) {
 						j[pLevel] = 0;
 						bricks[pLevel] = {};
 						styleInfo[pLevel] = {};
+						rowHTML[pLevel] = {};
 						pLevel--;
 						break;
 					case "}":


### PR DESCRIPTION
# Description

Some internal variables weren't getting properly reset during parsing, resulting in duplication of bricks in some cases.

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
