### PR TITLE
Fix initial DSH beard prediction

### DIFF
--- a/src/relay/chit_brickGear.ash
+++ b/src/relay/chit_brickGear.ash
@@ -1068,14 +1068,14 @@ int getCurrBeardNum() {
 int getLastBeardNum() {
 	effect lastBeard = get_property("lastBeardBuff").to_effect();
 	if(lastBeard == $effect[none]) {
-		return -1;
+		return 0;
 	}
 	foreach i,beard in getBeardOrder() {
 		if(beard == lastBeard) {
 			return i;
 		}
 	}
-	return -1;
+	return 0;
 }
 
 effect getNextBeard() {
@@ -1083,10 +1083,6 @@ effect getNextBeard() {
 	int currBeardNum = getCurrBeardNum();
 	if(currBeardNum == -1) {
 		int lastBeardNum = getLastBeardNum();
-		if(lastBeardNum == -1) {
-			// now that it's mafia tracked we can trust that it's reliable enough
-			beardOrder[0];
-		}
 		return beardOrder[(lastBeardNum + 1) % 11];
 	}
 	return beardOrder[(currBeardNum + 1) % 11];


### PR DESCRIPTION
# Description

DSH's beard prediction is wrong when you haven't received your first beard yet, always telling you that your first beard will be +item beard, which is actually always the last beard you'll get. This moves your default predicted beard forward by 1 (if mafia has not seen any beards yet this run).

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
