### PR TITLE
Use manifest file to support git installs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,3 @@
+{
+  "root_directory": "src"
+}


### PR DESCRIPTION
# Description

Recent changes to Mafia support installing using `git` instead of `svn`, which should provide a more consistent update experience for GitHub-hosted Mafia scripts.

This change adds a manifest file (as detailed in https://github.com/kolmafia/kolmafia/pull/911) to support `git checkout` without breaking the existing svn installs.

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
