### PR TITLE
Bump required version of mafia to r26597

### DIFF
--- a/src/relay/charpane.ash
+++ b/src/relay/charpane.ash
@@ -1,5 +1,5 @@
 script "Character Information Toolbox";
-since r26534; // sweatpants
+since r26597; // mafia support for git w subfolders
 import "chit_global.ash";
 import "chit_brickFamiliar.ash"; // This has to be before chit_brickGear due to addItemIcon() and... weirdly enough pickerFamiliar()
 import "chit_brickGear.ash";


### PR DESCRIPTION
r26597 extends mafia's git support to allow installing projects from subfolders.

This version is required for installation via 'git checkout' to work as expected.
