### PR TITLE
Don't show horsery brick if horsery is unusable

### DIFF
--- a/src/relay/chit_brickHorsery.ash
+++ b/src/relay/chit_brickHorsery.ash
@@ -85,7 +85,7 @@ void pickerHorse() {
 
 void bakeHorsery() {
 	// Nothing to do if you don't have the horsery
-	if(get_property("horseryAvailable").to_boolean() != true)
+	if(get_property("horseryAvailable").to_boolean() != true || !is_unrestricted($item[Horsery contract]))
 		return;
 
 	pickerHorse();


### PR DESCRIPTION
# Description

Recent Mafia changes mean that "horseryAvailable" check whether you've used the horsery contract or not, instead of whether it currently appears in Seaside Town.

## Screenshots

Omitted as the only difference is whether the brick appears in-run or not.

## Checklist:

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
