### PR TITLE
add 'spend rubees' link to the FantasyRealm G.E.M.

### DIFF
--- a/src/relay/chit_brickGear.ash
+++ b/src/relay/chit_brickGear.ash
@@ -1412,6 +1412,9 @@ void pickerGear(slot s) {
 			start_option(in_slot, true);
 			picker.append('<td colspan="2"><a class="visit done" target=mainpane ' +
 				'href="place.php?whichplace=realm_fantasy">Visit FantasyRealm.</a></td></tr>');
+			start_option(in_slot, true);
+			picker.append('<td colspan="2"><a class="visit done" target=mainpane ' +
+				'href="shop.php?whichshop=fantasyrealm">Spend Rubees.</a></td></tr>');
 			break;
 		case $item[PirateRealm eyepatch]:
 			start_option(in_slot, true);


### PR DESCRIPTION
# Description

Adds a link for the Rubee Shop to the FantasyRealm G.E.M item in the gear brick.  This link is normally in an extra box at the bottom of the normal charpane, and no longer exists when using ChIT.


## Screenshots

Without change:
![image](https://user-images.githubusercontent.com/31893300/226178390-147b1bae-a5c9-487d-b4ba-339be438fc07.png)

With change:
![image](https://user-images.githubusercontent.com/31893300/226178322-f4b9ece8-67f0-4bda-8ce6-338f8ffd5a00.png)

## Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have based by pull request against the [main branch](https://github.com/Loathing-Associates-Scripting-Society/ChIT/tree/main) or have a good reason not to.
